### PR TITLE
add apps-list link pointing to wiki

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
                 <a class="nav-link active" aria-current="page" href="install.html">Install</a>
               </li>
               <li class="nav-item">
+                <a class="nav-link active" aria-current="page" href="https://github.com/Botspot/pi-apps/wiki/Apps-List">Apps List</a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link active" aria-current="page" href="support.html">Support</a>
               </li>                            
               <li class="nav-item">


### PR DESCRIPTION
I thought it would be nice to have a way to view the apps list from this website.

I'm not familiar with html too much so this its easier to link to the wiki instead of recreating the apps list generation code in html, setting up github actions here (unless markdown can be used on this website as well), etc